### PR TITLE
Add email validation script

### DIFF
--- a/output.txt
+++ b/output.txt
@@ -1,0 +1,29 @@
+Email Validation Report:
+
+VALID: abby@emergencydisasterservices.com
+VALID: cody@emergencydisasterservices.com
+VALID: jerry@emergencydisasterservices.com
+VALID: JBrandt@garner-es.com
+VALID: cbreckenridge@slsco.com
+VALID: Emendel@texasdisposal.com
+VALID: jordan@grannysalliance.com
+VALID: cwalker@garner-es.com
+VALID: Michaelh@employeehousing.com
+VALID: seth@employeehousing.com
+VALID: doug@grannysalliance.com
+VALID: b.alphin@industrialentsystems.com
+VALID: lucas@apexsites.com
+VALID: kbatey@teamhousing.com
+VALID: paul.switzer@atco.com
+VALID: eddie@kellymobilecity.com
+VALID: r.cheek@industrialentsystems.com
+VALID: ron@emergencydisasterservices.com
+VALID: don.brazil@usaupstar.com
+VALID: klay.south@usaupstar.com
+VALID: krodriguez@propacusa.com
+VALID: blakef@phoenixpollution.com
+VALID: jed.smith@rvbtransport.com
+VALID: erogers@texaspridedisposal.com
+VALID: npompa@propacusa.com
+VALID: mochoa@rruniversalsolutions.com
+VALID: jchavez@rruniversalsolutions.com

--- a/validate_emails.py
+++ b/validate_emails.py
@@ -1,0 +1,54 @@
+import re
+
+EMAILS = [
+    "abby@emergencydisasterservices.com",
+    "cody@emergencydisasterservices.com",
+    "jerry@emergencydisasterservices.com",
+    "JBrandt@garner-es.com",
+    "cbreckenridge@slsco.com",
+    "Emendel@texasdisposal.com",
+    "jordan@grannysalliance.com",
+    "cwalker@garner-es.com",
+    "Michaelh@employeehousing.com",
+    "seth@employeehousing.com",
+    "doug@grannysalliance.com",
+    "b.alphin@industrialentsystems.com",
+    "lucas@apexsites.com",
+    "kbatey@teamhousing.com",
+    "paul.switzer@atco.com",
+    "eddie@kellymobilecity.com",
+    "r.cheek@industrialentsystems.com",
+    "ron@emergencydisasterservices.com",
+    "don.brazil@usaupstar.com",
+    "klay.south@usaupstar.com",
+    "krodriguez@propacusa.com",
+    "blakef@phoenixpollution.com",
+    "jed.smith@rvbtransport.com",
+    "erogers@texaspridedisposal.com",
+    "npompa@propacusa.com",
+    "mochoa@rruniversalsolutions.com",
+    "jchavez@rruniversalsolutions.com",
+]
+
+pattern = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9._%+-]*[A-Za-z0-9])?@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$")
+
+report = []
+for email in EMAILS:
+    if pattern.match(email):
+        report.append(f"VALID: {email}")
+    else:
+        reason = []
+        if '@' not in email:
+            reason.append("missing '@'")
+        if email.startswith('@') or email.endswith('@'):
+            reason.append("missing local or domain part")
+        if not re.search(r"\.[A-Za-z]{2,}$", email):
+            reason.append("domain TLD missing or too short")
+        if not reason:
+            reason.append("does not match standard email format")
+        report.append(f"INVALID: {email} - {'; '.join(reason)}")
+
+if __name__ == "__main__":
+    print("Email Validation Report:\n")
+    for line in report:
+        print(line)


### PR DESCRIPTION
## Summary
- add a Python script `validate_emails.py` to validate a list of emails using a regex pattern
- include generated output from running the script in `output.txt`

## Testing
- `python3 validate_emails.py > output.txt && cat output.txt`

------
https://chatgpt.com/codex/tasks/task_e_6866b4df4bac8320b0f43ea95dccfde2